### PR TITLE
Add biosketch links

### DIFF
--- a/assets/data/people.json
+++ b/assets/data/people.json
@@ -9,7 +9,8 @@
         "email": null,
         "linkedin": null,
         "x": null,
-        "orcid": null
+        "orcid": null,
+        "biosketch": "23540-eilis-hannon"
     },
     "Jessica Shields": {
         "name": "Jessica Shields",
@@ -21,7 +22,8 @@
         "email": null,
         "linkedin": null,
         "x": null,
-        "orcid": null
+        "orcid": null,
+        "biosketch": "38292-jessica-shields"
     },
     "Siyi Wang": {
         "name": "Siyi Wang",
@@ -33,7 +35,8 @@
         "email": "s.w.wang@exeter.ac.uk",
         "linkedin": null,
         "x": null,
-        "orcid": null
+        "orcid": null,
+        "biosketch": null
     },
     "Sam Fletcher": {
         "name": "Sam Fletcher",
@@ -45,6 +48,7 @@
         "email": "s.o.fletcher@exeter.ac.uk",
         "linkedin": "sam-fletcher-6830511b9",
         "x": null,
-        "orcid": null
+        "orcid": null,
+        "biosketch": "41890-sam-fletcher"
     }
 }

--- a/assets/sass/people.scss
+++ b/assets/sass/people.scss
@@ -30,6 +30,11 @@
 /* ------------------- */
 /* INDIVIDUAL PROFILES */
 /* ------------------- */
+.profile_picture_container {
+    display: flex;
+    justify-content: center;
+}
+
 .profile_picture {
     object-fit: cover;
     width: 70%;
@@ -41,7 +46,7 @@
 .person-profile h1 {
     margin: 0;
     height: 10%;
-    cursor: default;
+    color: $text_dark_green;
 }
 
 .person-profile .link-tree {
@@ -67,6 +72,10 @@
     height: 100%;
     width: 100%;
     max-height: 100px;
+}
+
+.name-container {
+    text-decoration: none;
 }
 
 /* ------- */

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -44,9 +44,11 @@
         {{ if eq .alumni $is_alumni_page }}
         <div id='{{ replace .name " " "" | lower}}' class="person-profile {{ .theme | lower }} {{ .position | lower }}">
             {{ $profile_picture := printf "/images/profile_pictures/%s" .image }}
-            {{ with resources.Get $profile_picture }}
-            <img class="profile_picture" src="{{ .RelPermalink }}"></img>
-            {{ end }}
+            <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}">
+                {{ with resources.Get $profile_picture }}
+                <img class="profile_picture" src="{{ .RelPermalink }}"></img>
+                {{ end }}
+            </a>
             <div class="link-tree">
                 {{ if .github }}
                 <a href="https://github.com/{{ .github}}" target="_blank">
@@ -74,9 +76,9 @@
                 </a>
                 {{ end }}
             </div>
-            <div class="name">
+            <a class="name-container" href="https://experts.exeter.ac.uk/{{ .biosketch }}">
                 <h1>{{ .name }}</h1>
-            </div>
+            </a>
         </div>
         {{ end }}
         {{ end}}

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -44,7 +44,7 @@
         {{ if eq .alumni $is_alumni_page }}
         <div id='{{ replace .name " " "" | lower}}' class="person-profile {{ .theme | lower }} {{ .position | lower }}">
             {{ $profile_picture := printf "/images/profile_pictures/%s" .image }}
-            <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" targer="_blank">
+            <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" target="_blank">
                 {{ with resources.Get $profile_picture }}
                 <img class="profile_picture" src="{{ .RelPermalink }}"></img>
                 {{ end }}

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -44,7 +44,7 @@
         {{ if eq .alumni $is_alumni_page }}
         <div id='{{ replace .name " " "" | lower}}' class="person-profile {{ .theme | lower }} {{ .position | lower }}">
             {{ $profile_picture := printf "/images/profile_pictures/%s" .image }}
-            <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}">
+            <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" targer="_blank">
                 {{ with resources.Get $profile_picture }}
                 <img class="profile_picture" src="{{ .RelPermalink }}"></img>
                 {{ end }}
@@ -76,7 +76,7 @@
                 </a>
                 {{ end }}
             </div>
-            <a class="name-container" href="https://experts.exeter.ac.uk/{{ .biosketch }}">
+            <a class="name-container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" target="_blank">
                 <h1>{{ .name }}</h1>
             </a>
         </div>

--- a/scripts/processing_scripts/edit_people.py
+++ b/scripts/processing_scripts/edit_people.py
@@ -55,7 +55,8 @@ def get_people_information(name, field):
         "email": "Ex: j.a.doe@exeter.ac.uk",
         "linkedin": "The string after the last '/' in your profile's url",
         "x": "Your X username, don't include the @",
-        "orcid": "16 digit number, Ex: 0009-0000-4090-9258"
+        "orcid": "16 digit number, Ex: 0009-0000-4090-9258",
+        "biosketch": "The string after the last '/' in your biosketch's url"
     }
     example_text = example_texts.get(field, "")
     if field == "alumni":
@@ -80,7 +81,8 @@ def add_person(json_file, name, profile_picture):
                           "email": None,
                           "linkedin": None,
                           "x": None,
-                          "orcid": None}
+                          "orcid": None,
+                          "biosketch": None}
 
     print(f"""
 ===============================================================================


### PR DESCRIPTION
## Description
This pull request will add the newly released UoE biosketch links to the people pages.

## Problems
There is a seemingly random number in the links to biosketches, so they cannot be purely inferred from a person's name (more inputs required).

The only way around this that I see currently is:
- Hope these numbers don't change in the future 
- Make the search and manually search for the person's profile from the search list. This is technically web scraping, so this might not be approved by the university.


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
