### PR TITLE
Add scroll animations to home page

### DIFF
--- a/assets/js/scroll-animation.js
+++ b/assets/js/scroll-animation.js
@@ -1,0 +1,24 @@
+const subTeamPhotos = document.querySelectorAll(".sub-team-photo");
+const subTeamInfo = document.querySelectorAll(".sub-team-info");
+
+const observerOptions = {
+    root: null,
+    rootMargin: "0px",
+    threshold: 0.5
+};
+
+const observer = new IntersectionObserver(function(elements, observer) {
+    elements.forEach(element => {
+        if (element.isIntersecting) {
+            element.target.classList.add('show')
+        }
+    });
+}, observerOptions);
+
+subTeamPhotos.forEach(photo => {
+    observer.observe(photo)
+});
+
+subTeamInfo.forEach(info => {
+    observer.observe(info)
+});

--- a/assets/sass/home.scss
+++ b/assets/sass/home.scss
@@ -47,17 +47,17 @@
     opacity: 0;
     transform: translateY(20px);
 
-    &>h2,
-    &>p {
+    >h2,
+    >p {
         transition: opacity 0.5s ease-out, transform 0.5s ease-out;
     }
 
-    &>h2 {
+    >h2 {
         opacity: 0;
         transform: translateY(-10px);
     }
 
-    &>p {
+    >p {
         opacity: 0;
         transform: translateY(10px);
     }
@@ -65,13 +65,13 @@
     &.show {
         opacity: 1;
 
-        &>h2 {
+        >h2 {
             opacity: 1;
             transform: translateY(0);
             transition-delay: 0.3s;
         }
 
-        &>p {
+        >p {
             opacity: 1;
             transform: translateY(0);
             transition-delay: 0.6s;

--- a/assets/sass/home.scss
+++ b/assets/sass/home.scss
@@ -44,6 +44,23 @@
     @include navigation-text;
     color: white;
     width: 50%;
+    opacity: 0;
+    transition: opacity 0.5s ease-out 0.5s, transform 1.5s ease-out;
+
+    &:nth-of-type(even) {
+        transform: translateX(20px);
+
+    }
+
+    &:nth-of-type(odd) {
+        transform: translateX(-20px);
+
+    }
+
+    &.show {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .sub-team-photo {
@@ -52,7 +69,23 @@
     align-items: center;
     justify-content: center;
     width: 50%;
+    opacity: 0;
+    transition: opacity 1s ease-out, transform 1s ease-out;
 
+    &:nth-of-type(even) {
+        transform: translateX(20px);
+
+    }
+
+    &:nth-of-type(odd) {
+        transform: translateX(-20px);
+
+    }
+
+    &.show {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .sub-team-photo img {

--- a/assets/sass/home.scss
+++ b/assets/sass/home.scss
@@ -45,21 +45,37 @@
     color: white;
     width: 50%;
     opacity: 0;
-    transition: opacity 0.5s ease-out 0.5s, transform 1.5s ease-out;
+    transform: translateY(20px);
 
-    &:nth-of-type(even) {
-        transform: translateX(20px);
-
+    &>h2,
+    &>p {
+        transition: opacity 0.5s ease-out, transform 0.5s ease-out;
     }
 
-    &:nth-of-type(odd) {
-        transform: translateX(-20px);
+    &>h2 {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
 
+    &>p {
+        opacity: 0;
+        transform: translateY(10px);
     }
 
     &.show {
         opacity: 1;
-        transform: translateY(0);
+
+        &>h2 {
+            opacity: 1;
+            transform: translateY(0);
+            transition-delay: 0.3s;
+        }
+
+        &>p {
+            opacity: 1;
+            transform: translateY(0);
+            transition-delay: 0.6s;
+        }
     }
 }
 

--- a/assets/sass/home.scss
+++ b/assets/sass/home.scss
@@ -47,17 +47,17 @@
     opacity: 0;
     transform: translateY(20px);
 
-    >h2,
-    >p {
+    h2,
+    p {
         transition: opacity 0.5s ease-out, transform 0.5s ease-out;
     }
 
-    >h2 {
+    h2 {
         opacity: 0;
         transform: translateY(-10px);
     }
 
-    >p {
+    p {
         opacity: 0;
         transform: translateY(10px);
     }
@@ -65,13 +65,13 @@
     &.show {
         opacity: 1;
 
-        >h2 {
+        h2 {
             opacity: 1;
             transform: translateY(0);
             transition-delay: 0.3s;
         }
 
-        >p {
+        p {
             opacity: 1;
             transform: translateY(0);
             transition-delay: 0.6s;

--- a/layouts/page/home.html
+++ b/layouts/page/home.html
@@ -72,3 +72,9 @@
     </div>
 </div>
 {{ end }}
+
+{{ define "scripts" }}
+{{ with resources.Get "js/scroll-animation.js" }}
+<script type="application/javascript" src="{{ .Permalink }}"></script>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
## Description
This pull request will add some lovely scroll animations to the home page. When the page is able to 'see' the team photos/info boxes, the text/photos will transition onto the screen.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
