### PR TITLE
feat: Add dark mode hover properties

### DIFF
--- a/assets/sass/collaborators.scss
+++ b/assets/sass/collaborators.scss
@@ -63,7 +63,7 @@
             height: 15px;
             width: 15px;
             margin: 0 2px;
-            background-color: #BBBBBB;
+            background-color: $navigation_hover_colour;
             border-radius: 50%;
             display: inline-block;
             transition: background-color 0.6s ease;
@@ -71,7 +71,7 @@
 
         .active,
         .dot-indicator:hover {
-            background-color: #555555;
+            background-color: $dark_navigation_hover_colour;
         }
     }
 

--- a/assets/sass/header.scss
+++ b/assets/sass/header.scss
@@ -33,7 +33,7 @@
         fill: white;
 
         &:hover {
-            fill: #AAAAAA;
+            fill: $navigation_hover_colour;
         }
     }
 
@@ -61,7 +61,7 @@
                 @include navigation-text(1.4rem);
 
                 .nav-text:hover {
-                    color: #AAAAAA;
+                    color: $navigation_hover_colour;
                 }
             }
 

--- a/assets/sass/header.scss
+++ b/assets/sass/header.scss
@@ -30,6 +30,11 @@
         justify-self: center;
         align-self: center;
         cursor: pointer;
+        fill: white;
+
+        &:hover {
+            fill: #AAAAAA;
+        }
     }
 
     .main-nav {

--- a/assets/sass/partials/theme.scss
+++ b/assets/sass/partials/theme.scss
@@ -6,6 +6,8 @@ $base_text_colour: #007D69;
 $light_text_colour: #00DDA5;
 $dark_text_colour: #003333;
 
+$navigation_hover_colour: #AAAAAA;
+$dark_navigation_hover_colour: #555555;
 
 $themes: (
     light: (text: $dark_text_colour,

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -79,7 +79,7 @@
         </ul>
     <div id="dark-toggle">
         <svg width="30px" height="30px" viewBox="0 0 512 512">
-            <path id="dark-toggle-button" fill="white" d="M256 160c-52.9 0-96 
+            <path id="dark-toggle-button" d="M256 160c-52.9 0-96 
                 43.1-96 96s43.1 96 96 96 96-43.1 96-96-43.1-96-96-96zm246.4 
                 80.5l-94.7-47.3 33.5-100.4c4.5-13.6-8.4-26.5-21.9-21.9l-100.4 
                 33.5-47.4-94.8c-6.4-12.8-24.6-12.8-31 0l-47.3 94.7L92.7 


### PR DESCRIPTION
## Description
This pull request will add hover properties to the dark mode toggle:

![image](https://github.com/user-attachments/assets/ce4afc5d-f3a5-4232-a466-a7d3c909654c)
![image](https://github.com/user-attachments/assets/a88772c6-adc4-4b26-af86-8608037486ed)


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
