### PR TITLE
docs: add link to documentation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ make this a private repository (hopefully the deployment still works).
 ## Documentation
 
 To learn how to run the site and how to contribute (*etc.*) head on over to the
-`documentation` directory of this repository.
+[documentation](https://github.com/EpigeneticsExeter/EpigenomicsLabWeb/tree/main/documentation) 
+directory of this repository.


### PR DESCRIPTION
## Description
This pull request will add a link to the README for redirecting users to the documentation

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [x] Documentation

## Checklist:
- [ ] I have checked that the site runs with no errors locally
