### PR TITLE
Fix:  collaborator text size and font

### DIFF
--- a/assets/sass/collaborators.scss
+++ b/assets/sass/collaborators.scss
@@ -117,6 +117,7 @@
     }
 
     p {
+        @include main-text(1rem);
         margin: 1%;
     }
 }

--- a/assets/sass/collaborators.scss
+++ b/assets/sass/collaborators.scss
@@ -32,14 +32,14 @@
             width: 40%;
 
             h1 {
-                @include main-text(1rem);
+                @include main-text(2rem);
                 text-align: center;
             }
 
             p {
                 width: 95%;
                 text-align: right;
-                @include main-text(0.5rem);
+                @include main-text(1rem);
             }
         }
     }


### PR DESCRIPTION
## Description
This pull request will make the text on the collaborators page use the outfit font and also ensure that it is actually readable. Before the text was very small due to a mistake in #79.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
