### PR TITLE
Use partials to save space

### DIFF
--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -261,10 +261,12 @@ Partials can be imported using:
 There are some partials that can help you to achieve certain functionality on
 the site without having to write everything yourself.
 
-The first of these is a partial to import some sass. To use it add the
-following into your script:
+##### sass
 
-```
+The first of these is a partial to import some sass. To use it add the
+following into your template:
+
+```go
 {{ define "extra_head" }}
 {{ partial "partials/addSass.html" (dict "style" "sass/file-name.scss") }}
 {{ end }}

--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -253,37 +253,10 @@ Partials can be imported using:
 {{ partial "partials/name-of-partial.html" }}
 ```
 
-#### Important partials
+#### Useful partials
 
-There are some partials that can help you to achieve certain functionality on
-the site without having to write everything yourself.
-
-##### Sass partial
-
-The first of these is a partial to import some sass. To use it add the
-following into your template:
-
-```go
-{{ define "extra_head" }}
-{{ partial "partials/addSass.html" (dict "style" "sass/file-name.scss") }}
-{{ end }}
-```
-
-You'll want to change `file-name.scss` to the name of your `scss` file found
-in the `assets/sass` folder for this to work.
-
-##### Javascript partial
-
-If you want to use javascript, then add this to your template:
-
-```go
-{{ define "scripts" }}
-{{ partial "partials/addJS.html" (dict "jsfile" "js/file-name.js") }}
-{{ end }}
-```
-
-You'll want to change `file-name.js` to the name of your `js` file found
-in the `assets/js` folder for this to work.
+For some partials that will save you lots of time, head on over to 
+[this page](./Developers-useful-partials.md).
 
 ## Public
 

--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -273,6 +273,19 @@ following into your script:
 You'll want to change `file-name.scss` to the name of your `scss` file found
 in the `assets/sass` folder for this to work.
 
+##### Javascript
+
+If you want to use javascript, then add this to your template:
+
+```go
+{{ define "scripts" }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/file-name.js") }}
+{{ end }}
+```
+
+You'll want to change `file-name.js` to the name of your `js` file found
+in the `assets/js` folder for this to work.
+
 ## Public
 
 Don't touch anything in this directory (though looking around might

--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -102,7 +102,7 @@ pales in comparison). Other supersets of css exist of course, but the fact that
 hugo supports sass directly makes it the obvious choice.
 
 To add sass into your template, I emplore you to check out
-[this section](#important-partials).
+[this section](#sass-partial).
 
 ## Content
 
@@ -261,7 +261,7 @@ Partials can be imported using:
 There are some partials that can help you to achieve certain functionality on
 the site without having to write everything yourself.
 
-##### sass
+##### Sass partial
 
 The first of these is a partial to import some sass. To use it add the
 following into your template:
@@ -275,7 +275,7 @@ following into your template:
 You'll want to change `file-name.scss` to the name of your `scss` file found
 in the `assets/sass` folder for this to work.
 
-##### Javascript
+##### Javascript partial
 
 If you want to use javascript, then add this to your template:
 

--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -101,6 +101,9 @@ one. Sass allows for partial files, mixins, global variables and more (css
 pales in comparison). Other supersets of css exist of course, but the fact that
 hugo supports sass directly makes it the obvious choice.
 
+To add sass into your template, I emplore you to check out
+[this section](#important-partials).
+
 ## Content
 
 The markdown files found in this directory directly correspond with pages on
@@ -252,6 +255,23 @@ Partials can be imported using:
 ```go
 {{ partial "partials/name-of-partial.html" }}
 ```
+
+#### Important partials
+
+There are some partials that can help you to achieve certain functionality on
+the site without having to write everything yourself.
+
+The first of these is a partial to import some sass. To use it add the
+following into your script:
+
+```
+{{ define "extra_head" }}
+{{ partial "partials/addSass.html" (dict "style" "sass/file-name.scss") }}
+{{ end }}
+```
+
+You'll want to change `file-name.scss` to the name of your `scss` file found
+in the `assets/sass` folder for this to work.
 
 ## Public
 

--- a/documentation/docs/Developers-directory-structure.md
+++ b/documentation/docs/Developers-directory-structure.md
@@ -101,9 +101,6 @@ one. Sass allows for partial files, mixins, global variables and more (css
 pales in comparison). Other supersets of css exist of course, but the fact that
 hugo supports sass directly makes it the obvious choice.
 
-To add sass into your template, I emplore you to check out
-[this section](#sass-partial).
-
 ## Content
 
 The markdown files found in this directory directly correspond with pages on

--- a/documentation/docs/Developers-useful-partials.md
+++ b/documentation/docs/Developers-useful-partials.md
@@ -1,0 +1,31 @@
+# Developers: Useful partials
+
+There are some partials that can help you to achieve certain functionality on
+the site without having to write everything yourself.
+
+## Sass
+
+The first of these is a partial to import some sass. To use it add the
+following into your template:
+
+```go
+{{ define "extra_head" }}
+{{ partial "partials/addSass.html" (dict "style" "sass/file-name.scss") }}
+{{ end }}
+```
+
+You'll want to change `file-name.scss` to the name of your `scss` file found
+in the `assets/sass` folder for this to work.
+
+## Javascript
+
+If you want to use javascript, then add this to your template:
+
+```go
+{{ define "scripts" }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/file-name.js") }}
+{{ end }}
+```
+
+You'll want to change `file-name.js` to the name of your `js` file found
+in the `assets/js` folder for this to work.

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/main.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/main.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,8 +6,9 @@
     <meta name="keywords" content="Epigenetics, Epigenomics, Lab, Exeter, Alzheimers, Schizophrenia, ADHD, Autism, Brain, Cancer, DNA, Methylation">
     <meta name="description" content="The home of epigentics research in Exeter UK">
     <link rel="icon" type="image/x-icon" href="/EpigenomicsLabWeb/favicon.ico">
-    {{ $style := resources.Get "sass/main.scss" | resources.ToCSS | resources.Fingerprint }}
-    <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+
+    {{ partial "partials/addSass.html" (dict "style" "sass/main.scss") }}
+
     <title>
         {{ block "title" . }}
         {{ .Site.Title }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,12 +34,8 @@
     {{ block "scripts" . }}
     {{ end }}
 
-    {{ with resources.Get "js/dark-mode.js" }}
-    <script type="application/javascript" src="{{ .Permalink }}"></script>
-    {{ end }}
-    {{ with resources.Get "js/sub_navigation.js" }}
-    <script type="application/javascript" src="{{ .Permalink }}"></script>
-    {{ end }}
+    {{ partial "partials/addJS.html" (dict "jsfile" "js/dark-mode.js") }}
+    {{ partial "partials/addJS.html" (dict "jsfile" "js/sub_navigation.js") }}
 </body>
 
 </html>

--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/blog.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/blog.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/page/contact-us.html
+++ b/layouts/page/contact-us.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/contact-us.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/contact-us.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/page/contact-us.html
+++ b/layouts/page/contact-us.html
@@ -68,7 +68,5 @@
 {{ end }}
 
 {{ define "scripts" }}
-{{ with resources.Get "js/pty_button.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/pty_button.js") }}
 {{ end }}

--- a/layouts/page/home.html
+++ b/layouts/page/home.html
@@ -73,7 +73,5 @@
 {{ end }}
 
 {{ define "scripts" }}
-{{ with resources.Get "js/scroll-animation.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/scroll-animation.js") }}
 {{ end }}

--- a/layouts/page/home.html
+++ b/layouts/page/home.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/home.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/home.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/partials/addJS.html
+++ b/layouts/partials/addJS.html
@@ -1,0 +1,4 @@
+{{ with resources.Get .jsfile }}
+<script type="application/javascript" src="{{ .Permalink }}"></script>
+{{ end }}
+

--- a/layouts/partials/addSass.html
+++ b/layouts/partials/addSass.html
@@ -1,0 +1,2 @@
+{{ $style := resources.Get .style | resources.ToCSS | resources.Fingerprint }}
+<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">

--- a/layouts/projectshome/single.html
+++ b/layouts/projectshome/single.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/blog.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/blog.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/alumni.html
+++ b/layouts/section/alumni.html
@@ -10,8 +10,6 @@
 
 
 {{ define "scripts" }}
-{{ with resources.Get "js/people_filtering.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/people_filtering.js") }}
 {{ end }}
 

--- a/layouts/section/alumni.html
+++ b/layouts/section/alumni.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/people.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/people.scss") }}
 {{ end }}
 
 

--- a/layouts/section/blogSelection.html
+++ b/layouts/section/blogSelection.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/blogSelection.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/blogSelection.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/code.html
+++ b/layouts/section/code.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/code.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/code.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/collaborators.html
+++ b/layouts/section/collaborators.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/collaborators.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/collaborators.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/collaborators.html
+++ b/layouts/section/collaborators.html
@@ -60,7 +60,5 @@
 {{ end }}
 
 {{ define "scripts" }}
-{{ with resources.Get "js/collaborator_slideshow.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/collaborator_slideshow.js") }}
 {{ end }}

--- a/layouts/section/funders.html
+++ b/layouts/section/funders.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/funders.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/funders.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/opportunities.html
+++ b/layouts/section/opportunities.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/opportunities.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/opportunities.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/opportunities.html
+++ b/layouts/section/opportunities.html
@@ -56,7 +56,5 @@
 {{ end }}
 
 {{ define "scripts" }}
-{{ with resources.Get "js/opportunity_filtering.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/opportunity_filtering.js") }}
 {{ end }}

--- a/layouts/section/people.html
+++ b/layouts/section/people.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/people.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/people.scss") }}
 {{ end }}
 
 

--- a/layouts/section/people.html
+++ b/layouts/section/people.html
@@ -3,14 +3,11 @@
 {{ end }}
 
 
-
 {{ define "main" }}
 {{ partial "partials/people.html" . }}
 {{ end }}
 
 
 {{ define "scripts" }}
-{{ with resources.Get "js/people_filtering.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/people_filtering.js") }}
 {{ end }}

--- a/layouts/section/projectsHome.html
+++ b/layouts/section/projectsHome.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/projectsHome.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/projectsHome.scss") }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/section/publications.html
+++ b/layouts/section/publications.html
@@ -1,6 +1,5 @@
 {{ define "extra_head" }}
-{{ $style := resources.Get "sass/publications.scss" | resources.ToCSS | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+{{ partial "partials/addSass.html" (dict "style" "sass/publications.scss") }}
 {{ end }}
 
 

--- a/layouts/section/publications.html
+++ b/layouts/section/publications.html
@@ -107,11 +107,6 @@
 
 
 {{ define "scripts" }}
-{{ with resources.Get "js/publication_filtering.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
-
-{{ with resources.Get "js/expand_publication.js" }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
-{{ end }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/publication_filtering.js") }}
+{{ partial "partials/addJS.html" (dict "jsfile" "js/expand_publication.js") }}
 {{ end }}


### PR DESCRIPTION
## Description
This pull request will create two partials:
- One to input any sass files
- One to input any JavaScript files

This saves on copying and pasting a big chunk of text between different templates and means if this code needs to be changed at any point, we can do them all at the same time.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [x] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
