### PR TITLE
Use json files for the repositories on the code page

### DIFF
--- a/assets/data/repositories.json
+++ b/assets/data/repositories.json
@@ -1,0 +1,18 @@
+{
+    "brainfans": {
+        "username": "ejh243",
+        "repo": "BrainFANS"
+    },
+    "cdeg utilities": {
+        "username": "EpigeneticsExeter",
+        "repo": "cdegUtilities"
+    },
+    "chrombinarize": {
+        "username": "sof202",
+        "repo": "ChromBinarize"
+    },
+    "chromoptimise": {
+        "username": "sof202",
+        "repo": "ChromOptimise"
+    }
+}

--- a/content/code/brainfans.md
+++ b/content/code/brainfans.md
@@ -1,5 +1,0 @@
-+++
-[params]
-    username = "ejh243"
-    repo = "BrainFANS"
-+++

--- a/content/code/cdegutilities.md
+++ b/content/code/cdegutilities.md
@@ -1,5 +1,0 @@
-+++
-[params]
-    username = "EpigeneticsExeter"
-    repo = "cdegUtilities"
-+++

--- a/content/code/chrombinarize.md
+++ b/content/code/chrombinarize.md
@@ -1,5 +1,0 @@
-+++
-[params]
-    username = "sof202"
-    repo = "ChromBinarize"
-+++

--- a/content/code/chromoptimise.md
+++ b/content/code/chromoptimise.md
@@ -1,5 +1,0 @@
-+++
-[params]
-    username = "sof202"
-    repo = "ChromOptimise"
-+++

--- a/documentation/docs/Users-changing-code-page.md
+++ b/documentation/docs/Users-changing-code-page.md
@@ -1,22 +1,13 @@
 # Users: How to change the repositories on the code page
 
-This is subject to change, but currently if you want to change the repositories
-seen on the code page of the site you'll need to do the following:
+There is currently no script that can assist you in changing the currently
+shown code repositories. As a result, you'll need to change the file yourself.
+This page knows which code repositories to show using a `json` file found at
+`assets/data/repositories.json`.
 
-## Step 1
+## Fields
 
-Move over to the `content/code` directory in this repository.
-
-## Step 2
-
-You'll now want to delete, add or change one of the `.md` files found in this
-directory. The names of the files don't actually matter currently, they are
-purely for organisational purposes.
-
-### Fields
-
-Each file is actually just a bit of `.toml` and no markdown is actually
-required. The fields required are as follows:
+The fields required are as follows:
 
 - username: The username (or organisation) the repository belongs to
 - repo: The name of the repository
@@ -26,16 +17,15 @@ Notes:
 - Both of these fields are case sensitive
 - This currently only works for GitHub repositories
 
-### Example
+## Example
 
 To include the [BrainFANS](https://github.com/ejh243/BrainFANS) repository for
 example you would add:
 
-```toml
-+++
-[params]
-    username = "ejh243"
-    repo = "BrainFANS"
-+++
+```json
+"brainfans": {
+    "username": "ejh243",
+    "repo": "BrainFANS"
+}
 ```
 

--- a/layouts/section/code.html
+++ b/layouts/section/code.html
@@ -3,6 +3,16 @@
 {{ end }}
 
 {{ define "main" }}
+{{ $repo_data := dict }}
+{{ $path := "data/repositories.json" }}
+{{ with resources.Get $path }}
+  {{ with . | transform.Unmarshal }}
+    {{ $repo_data = . }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get global resource %q" $path }}
+{{ end }}
+
 <div class="description-container">
     <h1>Our Code Repositories</h1>
     <p>
@@ -14,10 +24,10 @@
     </p>
 </div>
 <div class="repository-grid">
-    {{ $theme := "default"}}
-    {{ range .Pages }}
-    <a href="https://github.com/{{ .Params.username }}/{{ .Params.repo }}" target="_blank" >
-        <img src="https://github-readme-stats.vercel.app/api/pin/?username={{ .Params.username }}&repo={{ .Params.repo }}&theme={{ $theme }}">
+    {{ $theme := "default" }}
+    {{ range $repo_data }}
+    <a href="https://github.com/{{ .username }}/{{ .repo }}" target="_blank" >
+        <img src="https://github-readme-stats.vercel.app/api/pin/?username={{ .username }}&repo={{ .repo }}&theme={{ $theme }}">
     </a>
     {{ end }}
 </div>


### PR DESCRIPTION
## Description
This pull request will switch to using a json file for generating the repositories shown on the code page of the site. This is to be consistent with every other page (publications, people, funders *etc.*).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
