### PR TITLE
fix: remove blank space bug

### DIFF
--- a/assets/sass/header.scss
+++ b/assets/sass/header.scss
@@ -72,7 +72,7 @@
                 opacity: 0;
                 transition: opacity 0.5s;
                 z-index: 120;
-                min-width: 80vw;
+                min-width: 50vw;
 
                 .sub-nav-item {
                     margin: 0 1%;


### PR DESCRIPTION
## Description
This pull request will fix the bug mentioned in #121. This was actually a problem since #40, but I didn't see it until #121 because the changes to the viewport in the meta tag actually revealed it. 

The problem was the sub nav bars being too big and causing the page to zoom out:
![image](https://github.com/user-attachments/assets/36aca5b4-1022-4d3c-9e2b-bd8952d5d4e1)

I just had to make these divs smaller.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
