### PR TITLE
fix: force profile cards to be fixed in size

### DIFF
--- a/assets/sass/people.scss
+++ b/assets/sass/people.scss
@@ -7,7 +7,7 @@
     align-self: flex-end;
     grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
     width: 70%;
-    grid-template-rows: repeat(auto-fill, 35vh);
+    grid-auto-rows: 35vh;
     margin: 1vh 1vw 1vh 31vw;
 
     .person-profile {


### PR DESCRIPTION
This helps with certain cards having overflow due to longer names.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
