### PR TITLE
Add personal website link

### DIFF
--- a/assets/data/people.json
+++ b/assets/data/people.json
@@ -243,7 +243,7 @@
         "linkedin": "ehsan-pishva-1b3b7145",
         "x": "EPishva",
         "orcid": "0000-0002-8964-0682",
-        "website": null,
+        "website": "https://www.maastrichtuniversity.nl/se-pishva",
         "biosketch": null
     },
     "Emily Fretwell": {
@@ -776,7 +776,7 @@
         "linkedin": null,
         "x": null,
         "orcid": "0000-0002-9954-1565",
-        "website": null,
+        "website": "https://www.researchgate.net/profile/Jonathan-Davies-14",
         "biosketch": null
     }
 }

--- a/assets/data/people.json
+++ b/assets/data/people.json
@@ -9,6 +9,7 @@
         "linkedin": "eilis-hannon-91070a6b",
         "x": null,
         "orcid": "0000-0001-6840-072X",
+        "website": null,
         "biosketch": "23540-eilis-hannon"
     },
     "Jessica Shields": {
@@ -21,6 +22,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "38292-jessica-shields"
     },
     "Rhian Swarbrick": {
@@ -33,6 +35,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Siyi Wang": {
@@ -45,6 +48,7 @@
         "linkedin": "siyi-wang-63052525a",
         "x": null,
         "orcid": "0000-0002-3754-2861",
+        "website": null,
         "biosketch": null
     },
     "Sam Fletcher": {
@@ -57,6 +61,7 @@
         "linkedin": "sam-fletcher-6830511b9",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "41890-sam-fletcher"
     },
     "Ann Babtie": {
@@ -69,6 +74,7 @@
         "linkedin": "ann-babtie-282a4a49",
         "x": "annbabtie",
         "orcid": "0000-0001-9357-8351",
+        "website": null,
         "biosketch": "38351-ann-babtie"
     },
     "Alice Franklin": {
@@ -81,6 +87,7 @@
         "linkedin": "alice-f-9a2905125",
         "x": null,
         "orcid": "0000-0001-9793-582X",
+        "website": null,
         "biosketch": "36457-alice-franklin"
     },
     "Amy Webster": {
@@ -93,6 +100,7 @@
         "linkedin": "amy-webster-57b91a81",
         "x": null,
         "orcid": "0000-0002-9824-2627",
+        "website": null,
         "biosketch": "35215-amy-webster"
     },
     "Anthony Klokkaris": {
@@ -105,6 +113,7 @@
         "linkedin": "anthony-klokkaris-3b9b06146",
         "x": null,
         "orcid": "0000-0001-8599-3109",
+        "website": null,
         "biosketch": "35312-anthony-klokkaris"
     },
     "Alessia Mauri": {
@@ -117,6 +126,7 @@
         "linkedin": "alessia-mauri-3a64b4197",
         "x": null,
         "orcid": "0000-0001-5675-5347",
+        "website": null,
         "biosketch": null
     },
     "Ailsa Maccalman": {
@@ -129,6 +139,7 @@
         "linkedin": "ailsa-maccalman-29385b121",
         "x": null,
         "orcid": "0009-0005-7510-7130",
+        "website": null,
         "biosketch": "41994-ailsa-maccalman"
     },
     "Adam Smith": {
@@ -141,6 +152,7 @@
         "linkedin": null,
         "x": null,
         "orcid": "0000-0001-6495-2711",
+        "website": null,
         "biosketch": "27348-adam-smith"
     },
     "Barry Chioza": {
@@ -153,6 +165,7 @@
         "linkedin": "barry-chioza-thx1138",
         "x": null,
         "orcid": "0000-0002-3546-1726",
+        "website": null,
         "biosketch": "23178-barry-chioza"
     },
     "Bethan Mallabar-Rimmer": {
@@ -165,6 +178,7 @@
         "linkedin": "bethanrimmer",
         "x": null,
         "orcid": "0009-0004-4345-8414",
+        "website": null,
         "biosketch": null
     },
     "Darren Soanes": {
@@ -177,6 +191,7 @@
         "linkedin": "darren-soanes-94779550",
         "x": "darren_soanes",
         "orcid": "0000-0001-5025-295X",
+        "website": null,
         "biosketch": "249-darren-soanes"
     },
     "Ashim Deb": {
@@ -189,6 +204,7 @@
         "linkedin": "ashim-deb-64436598",
         "x": null,
         "orcid": "0000-0003-0208-8619",
+        "website": null,
         "biosketch": null
     },
     "Ellie Hendy": {
@@ -201,6 +217,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "38179-ellie-hendy"
     },
     "Emma Dempster": {
@@ -213,6 +230,7 @@
         "linkedin": "emma-dempster-890732127",
         "x": "ElkyD",
         "orcid": "0000-0003-1257-5314",
+        "website": null,
         "biosketch": "22394-emma-dempster"
     },
     "Ehsan Pishva": {
@@ -225,6 +243,7 @@
         "linkedin": "ehsan-pishva-1b3b7145",
         "x": "EPishva",
         "orcid": "0000-0002-8964-0682",
+        "website": null,
         "biosketch": null
     },
     "Emily Fretwell": {
@@ -237,6 +256,7 @@
         "linkedin": "emily-fretwell-962375204",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Emily Trusler": {
@@ -249,6 +269,7 @@
         "linkedin": "emily-trusler-4882a7164",
         "x": null,
         "orcid": "0009-0008-9485-0204",
+        "website": null,
         "biosketch": null
     },
     "Emma Walker": {
@@ -261,6 +282,7 @@
         "linkedin": "emma-walker-b7664a293",
         "x": null,
         "orcid": "0000-0003-2222-4577",
+        "website": null,
         "biosketch": "27979-emma-walker"
     },
     "Fergus Fones": {
@@ -273,6 +295,7 @@
         "linkedin": "fergus-fones-8931a4216",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Gina Commin": {
@@ -285,6 +308,7 @@
         "linkedin": null,
         "x": null,
         "orcid": "0000-0002-6485-799X",
+        "website": null,
         "biosketch": "33454-gina-commin"
     },
     "Grace Thomson": {
@@ -297,6 +321,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Giulia Pegoraro": {
@@ -309,6 +334,7 @@
         "linkedin": "giulia-pegoraro-8554361b0",
         "x": "GiuliaPegoraro7",
         "orcid": "0009-0001-5206-5303",
+        "website": null,
         "biosketch": null
     },
     "Greg Wheildon": {
@@ -321,6 +347,7 @@
         "linkedin": null,
         "x": "GregWheildon",
         "orcid": "0000-0002-7911-9973",
+        "website": null,
         "biosketch": "32538-greg-wheildon"
     },
     "Isabel Castanho": {
@@ -333,6 +360,7 @@
         "linkedin": "i.s.castanho@exeter.ac.ukisabelcastanho",
         "x": "isabelscst",
         "orcid": "0000-0003-1413-626X",
+        "website": "https://www.dementiaresearcher.nihr.ac.uk/podcast-profile-isabel-castanho/",
         "biosketch": null
     },
     "Isabel Larkin": {
@@ -345,6 +373,7 @@
         "linkedin": "isabellarkin",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Imran Haikal": {
@@ -357,6 +386,7 @@
         "linkedin": "imranhaikal",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Joe Burrage": {
@@ -369,6 +399,7 @@
         "linkedin": "joe-burrage-16823674",
         "x": null,
         "orcid": "0009-0002-1567-713X",
+        "website": null,
         "biosketch": "22777-joe-burrage"
     },
     "Jonathan Mill": {
@@ -381,6 +412,7 @@
         "linkedin": "jonathan-mill-64b32a134",
         "x": "PsyEpigenetics",
         "orcid": "0000-0003-1115-3224",
+        "website": null,
         "biosketch": "22368-jonathan-mill"
     },
     "Joshua Harvey": {
@@ -393,6 +425,7 @@
         "linkedin": "joshuadharvey",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Jenny Imm": {
@@ -405,6 +438,7 @@
         "linkedin": "jennifer-imm-2631699a",
         "x": "jenny_imm",
         "orcid": "0000-0002-8827-8669",
+        "website": null,
         "biosketch": "32552-jenny-imm"
     },
     "Katie Lunnon": {
@@ -417,6 +451,7 @@
         "linkedin": "katie-lunnon-a1004539",
         "x": null,
         "orcid": "0000-0001-7570-6065",
+        "website": null,
         "biosketch": "22834-katie-lunnon"
     },
     "Kirtikesav Salem Saravanaraj": {
@@ -429,6 +464,7 @@
         "linkedin": "kirtikesav-s-75875611a",
         "x": null,
         "orcid": "0000-0001-5212-1574",
+        "website": null,
         "biosketch": "40541-kirtikesav-salem-saravanaraj"
     },
     "Katie Jefferies": {
@@ -441,6 +477,7 @@
         "linkedin": "katie-jefferies-527958195",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Kamile Tamusauskaite": {
@@ -453,6 +490,7 @@
         "linkedin": "kamile-tamusauskaite",
         "x": "tamusauskaite",
         "orcid": "0000-0003-1649-3439",
+        "website": null,
         "biosketch": "40640-kamile-tamusauskaite"
     },
     "Lachlan Ford MacBean": {
@@ -465,6 +503,7 @@
         "linkedin": "lachlan-ford-macbean",
         "x": null,
         "orcid": "0009-0001-2437-8329",
+        "website": null,
         "biosketch": null
     },
     "Luke Weymouth": {
@@ -477,6 +516,7 @@
         "linkedin": "luke-weymouth-7b6ab072",
         "x": null,
         "orcid": "0000-0002-1168-6015",
+        "website": null,
         "biosketch": "25078-luke-weymouth"
     },
     "Marina Flores Payan": {
@@ -489,6 +529,7 @@
         "linkedin": "marina-flores-payan-1b69541a3",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "41901-marina-flores-payan"
     },
     "Morteza Kouhsar": {
@@ -501,6 +542,7 @@
         "linkedin": "morteza-kouhsar-2618085a",
         "x": "MortezaKouhsar",
         "orcid": "0000-0001-6092-3016",
+        "website": null,
         "biosketch": "36846-morteza-kouhsar"
     },
     "Molly Endicott": {
@@ -513,6 +555,7 @@
         "linkedin": "molly-endicott-87036139",
         "x": null,
         "orcid": "0000-0001-8097-0987",
+        "website": null,
         "biosketch": "37736-molly-endicott"
     },
     "Marty Frith": {
@@ -525,6 +568,7 @@
         "linkedin": "martyn-frith-543815206",
         "x": null,
         "orcid": "0009-0005-2422-9904",
+        "website": null,
         "biosketch": "40589-marty-frith"
     },
     "Michael Schrauben": {
@@ -537,6 +581,7 @@
         "linkedin": "michael-schrauben-2132b9126",
         "x": null,
         "orcid": "0000-0003-2597-5253",
+        "website": null,
         "biosketch": null
     },
     "Maddie Sharp": {
@@ -549,6 +594,7 @@
         "linkedin": "maddie-sharp-7890b2279",
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Millie Sander-Long": {
@@ -561,6 +607,7 @@
         "linkedin": null,
         "x": "millie-sander",
         "orcid": "0000-0002-9639-5590",
+        "website": null,
         "biosketch": null
     },
     "Nicholas Clifton": {
@@ -573,6 +620,7 @@
         "linkedin": "nicholas-clifton-4b18b368",
         "x": "NE_Clifton",
         "orcid": "0000-0003-2597-5253",
+        "website": null,
         "biosketch": "38790-nicholas-clifton"
     },
     "Philippa Wells": {
@@ -585,6 +633,7 @@
         "linkedin": "philippa-wells-1a677213a",
         "x": null,
         "orcid": "0000-0003-0139-1624",
+        "website": null,
         "biosketch": "42890-philippa-wells"
     },
     "Patrick O\u2019neill": {
@@ -597,6 +646,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": null
     },
     "Bex Smith": {
@@ -609,6 +659,7 @@
         "linkedin": null,
         "x": null,
         "orcid": "0000-0001-9264-1056",
+        "website": null,
         "biosketch": "24699-bex-smith"
     },
     "Rosie Bamford": {
@@ -621,6 +672,7 @@
         "linkedin": "rb520@exeter.ac.uk",
         "x": "rbamford5",
         "orcid": "0000-0002-2107-4637",
+        "website": null,
         "biosketch": "24506-rosie-bamford"
     },
     "Rhiannon Haigh": {
@@ -633,6 +685,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "42494-rhiannon-haigh"
     },
     "Szi Kay Leung": {
@@ -645,6 +698,7 @@
         "linkedin": "szikayleung",
         "x": "SKayLeung",
         "orcid": "0000-0002-5607-4688",
+        "website": null,
         "biosketch": "39044-szi-kay-leung"
     },
     "Tom Piers": {
@@ -657,6 +711,7 @@
         "linkedin": "thomaspiers",
         "x": null,
         "orcid": "0000-0003-1015-3417",
+        "website": null,
         "biosketch": "37418-tom-piers"
     },
     "Kartik Chundru": {
@@ -669,6 +724,7 @@
         "linkedin": "kartik-chundru-b786861b5",
         "x": "kartikchundru",
         "orcid": "0000-0002-6348-5565",
+        "website": null,
         "biosketch": "41357-kartik-chundru"
     },
     "Wendy Cowell": {
@@ -681,6 +737,7 @@
         "linkedin": null,
         "x": null,
         "orcid": null,
+        "website": null,
         "biosketch": "20646-wendy-cowell"
     },
     "Anna Migdalska-Richards": {
@@ -693,6 +750,7 @@
         "linkedin": "anna-migdalska-richards-585a5625a",
         "x": null,
         "orcid": "0000-0001-6992-0751",
+        "website": null,
         "biosketch": "27287-anna-migdalskarichards"
     },
     "Simeng Lin": {
@@ -705,6 +763,7 @@
         "linkedin": null,
         "x": "SimengLin",
         "orcid": "0000-0002-4201-4879",
+        "website": null,
         "biosketch": null
     },
     "Jonathan Davies": {
@@ -717,6 +776,7 @@
         "linkedin": null,
         "x": null,
         "orcid": "0000-0002-9954-1565",
+        "website": null,
         "biosketch": null
     }
 }

--- a/documentation/docs/Users-changing-personnel.md
+++ b/documentation/docs/Users-changing-personnel.md
@@ -77,6 +77,8 @@ Below is a quick definition of each field:
     (the bit that follows `uk.linkedin.com/in/`).
 - x: The person's x handle (following the @)
 - orcid: The 16 digit number (0000-1234-0000-9876)
+- website: A full weblink to a personal website
+    - Note: This is favoured over a biosketch if both are given.
 - biosketch: The person's UoE biosketch link
     (the bit that follows `https://experts.exeter.ac.uk/`)
 
@@ -95,6 +97,7 @@ Here's an example:
     "linkedin": null,
     "x": null,
     "orcid": null,
+    "website": null,
     "biosketch": "23540-eilis-hannon"
 },
 ```

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -92,7 +92,11 @@
                 </a>
                 {{ end }}
             </div>
+            {{ if .website }}
+                <a class="name-container" href="{{ .website }}" target="_blank">
+            {{ else }}
             <a class="name-container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" target="_blank">
+            {{ end }}
                 <h1>{{ .name }}</h1>
             </a>
         </div>

--- a/layouts/partials/people.html
+++ b/layouts/partials/people.html
@@ -54,7 +54,11 @@
         {{ end }}
         {{ if eq .alumni $is_alumni_page }}
         <div id='{{ replace .name " " "" | lower}}' class="person-profile {{ .theme | lower }} {{ .position | lower }}">
+            {{ if .website }}
+            <a class="profile_picture_container" href="{{ .website }}" target="_blank">
+            {{ else }}
             <a class="profile_picture_container" href="https://experts.exeter.ac.uk/{{ .biosketch }}" target="_blank">
+            {{ end }}
                 {{ with resources.Get $profile_picture }}
                     <img class="profile_picture" src="{{ .RelPermalink }}"></img>
                 {{ else }}

--- a/scripts/processing_scripts/edit_people.py
+++ b/scripts/processing_scripts/edit_people.py
@@ -41,6 +41,7 @@ def get_people_information(name, field):
         "linkedin": "The string after the last '/' in your profile's url",
         "x": "Your X username, don't include the @",
         "orcid": "16 digit number, Ex: 0009-0000-4090-9258",
+        "website": "A full link to your personal website",
         "biosketch": "The string after the last '/' in your biosketch's url"
     }
     example_text = example_texts.get(field, "")
@@ -66,6 +67,7 @@ def add_person(json_file, name):
                           "linkedin": None,
                           "x": None,
                           "orcid": None,
+                          "website": None,
                           "biosketch": None}
 
     print(f"""


### PR DESCRIPTION
## Description
This pull request will add a further field to the json file holding the members of the lab. This field will allow people to link their profile to a personal website. This is particularly useful for PTY students and certain alumni.

This doesn't even necessarily need to be a personal website, it can just link to a biosketch somewhere. Further, you could just create a new page on this website as your 'personal website', I really don't care.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
