### PR TITLE
Redesign link tree for dark mode

### DIFF
--- a/assets/sass/people.scss
+++ b/assets/sass/people.scss
@@ -22,7 +22,7 @@
         .link-tree {
             visibility: hidden;
             display: flex;
-            justify-content: space-evenly;
+            justify-content: space-between;
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
@@ -76,6 +76,10 @@
     }
 }
 
+
+.dark-theme .link-tree img {
+    filter: brightness(0) saturate(100%) invert(100%);
+}
 
 @media only screen and (max-width: $smaller_screen_threshold_width) {
     .people-photo-grid {

--- a/assets/sass/people.scss
+++ b/assets/sass/people.scss
@@ -22,17 +22,18 @@
         .link-tree {
             visibility: hidden;
             display: flex;
-            justify-content: space-between;
-            align-items: center;
+            justify-content: center;
             opacity: 0;
             transition: opacity 0.3s ease;
 
+            a {
+                margin: 1%;
 
-            img {
-                height: 4vh;
-                width: 100%;
+                img {
+                    height: 4vh;
+                    width: 100%;
+                }
             }
-
         }
 
         &:hover {


### PR DESCRIPTION
## Description
This pull request will fix the colours of the link trees on people pages when in dark mode (svgs go to white).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
