### PR TITLE
Add themes to repositories

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,5 +1,8 @@
+import { updateRepositoryURLs } from "./repositories-darkmode.js";
+
 const darkModeButton = document.getElementById("dark-toggle");
 const darkModeImage = document.getElementById("dark-toggle-button");
+let isDarkMode;
 
 const lightModePath =
     "M256 160c-52.9 0-96 43.1-96 96s43.1 96 96 96 96-43.1 96-96-43.1-96-96-96zm246.4 80.5l-94.7-47.3 33.5-100.4c4.5-13.6-8.4-26.5-21.9-21.9l-100.4 33.5-47.4-94.8c-6.4-12.8-24.6-12.8-31 0l-47.3 94.7L92.7 70.8c-13.6-4.5-26.5 8.4-21.9 21.9l33.5 100.4-94.7 47.4c-12.8 6.4-12.8 24.6 0 31l94.7 47.3-33.5 100.5c-4.5 13.6 8.4 26.5 21.9 21.9l100.4-33.5 47.3 94.7c6.4 12.8 24.6 12.8 31 0l47.3-94.7 100.4 33.5c13.6 4.5 26.5-8.4 21.9-21.9l-33.5-100.4 94.7-47.3c13-6.5 13-24.7.2-31.1zm-155.9 106c-49.9 49.9-131.1 49.9-181 0-49.9-49.9-49.9-131.1 0-181 49.9-49.9 131.1-49.9 181 0 49.9 49.9 49.9 131.1 0 181z";
@@ -18,15 +21,6 @@ function setLightMode() {
     document.body.classList.remove("dark-theme");
     document.body.classList.add("light-theme");
     updateRepositoryURLs("default");
-}
-
-function updateRepositoryURLs(theme) {
-    const repositories = document.querySelectorAll(".repository");
-    repositories.forEach((repository) => {
-        const url = new URL(repository.src);
-        url.searchParams.set("theme", theme);
-        repository.src = url;
-    });
 }
 
 function toggleDarkMode() {

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -13,6 +13,8 @@ function setDarkMode() {
     darkModeImage.setAttribute("d", darkModePath);
     document.body.classList.remove("light-theme");
     document.body.classList.add("dark-theme");
+
+    // Only required on Reproducability page
     updateRepositoryURLs("discord_old_blurple");
 }
 

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -10,12 +10,23 @@ function setDarkMode() {
     darkModeImage.setAttribute("d", darkModePath);
     document.body.classList.remove("light-theme");
     document.body.classList.add("dark-theme");
+    updateRepositoryURLs("discord_old_blurple");
 }
 
 function setLightMode() {
     darkModeImage.setAttribute("d", lightModePath);
     document.body.classList.remove("dark-theme");
     document.body.classList.add("light-theme");
+    updateRepositoryURLs("default");
+}
+
+function updateRepositoryURLs(theme) {
+    const repositories = document.querySelectorAll(".repository");
+    repositories.forEach((repository) => {
+        const url = new URL(repository.src);
+        url.searchParams.set("theme", theme);
+        repository.src = url;
+    });
 }
 
 function toggleDarkMode() {

--- a/assets/js/repositories-darkmode.js
+++ b/assets/js/repositories-darkmode.js
@@ -1,0 +1,9 @@
+export function updateRepositoryURLs(theme) {
+    const repositories = document.querySelectorAll(".repository");
+    repositories.forEach((repository) => {
+        const url = new URL(repository.src);
+        url.searchParams.set("theme", theme);
+        repository.src = url.toString();
+    });
+}
+

--- a/layouts/partials/addJS.html
+++ b/layouts/partials/addJS.html
@@ -1,4 +1,4 @@
 {{ with resources.Get .jsfile }}
-<script type="application/javascript" src="{{ .Permalink }}"></script>
+<script type="module" src="{{ .Permalink }}"></script>
 {{ end }}
 

--- a/layouts/section/reproducibility.html
+++ b/layouts/section/reproducibility.html
@@ -24,10 +24,9 @@
     </p>
 </div>
 <div class="repository-grid">
-    {{ $theme := "default" }}
     {{ range $repo_data }}
     <a href="https://github.com/{{ .username }}/{{ .repo }}" target="_blank" >
-        <img src="https://github-readme-stats.vercel.app/api/pin/?username={{ .username }}&repo={{ .repo }}&theme={{ $theme }}">
+        <img class="repository" src="https://github-readme-stats.vercel.app/api/pin/?username={{ .username }}&repo={{ .repo }}&theme=default">
     </a>
     {{ end }}
 </div>


### PR DESCRIPTION
## Description
This pull request will make the themes of the repository cards on the reproducibility page change in relation with the current status of dark mode.

As a part of this PR, all js is now added in as 'modules'. This should allow for some refactoring in the future (we can use 'export' and 'import'). New issues will be raised soon to outline the changes that can be made.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
