### PR TITLE
fix: force home href to be 200px wide

### DIFF
--- a/assets/sass/header.scss
+++ b/assets/sass/header.scss
@@ -18,10 +18,10 @@
     #logo {
         justify-self: flex-start;
         margin-right: 10%;
+        width: 200px;
 
         img {
-            margin-right: 10%;
-            width: 200px;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
