### PR TITLE
fix: add padding to help with mouse leave logic

### DIFF
--- a/assets/sass/header.scss
+++ b/assets/sass/header.scss
@@ -40,6 +40,8 @@
 
     .main-nav {
         display: flex;
+        margin: 0;
+        padding: 20px 0 20px 40px;
 
 
         ul {


### PR DESCRIPTION
## Description
Margins don't count as the element and so there was a mouse leave event occuring when moving the mouse to the sub navbars. This resulted in the sub navbar being set to invisible again unless you moved the mouse very fast.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
