### PR TITLE
Add several links to reproducibility page

### DIFF
--- a/assets/data/publication-data.json
+++ b/assets/data/publication-data.json
@@ -1,0 +1,57 @@
+{
+    "MeDIP-Seq": {
+        "title": "MeDIP-Seq brain data",
+        "description": "Tissue-specific epigenetic variation across brain and blood: functional annotation of the human brain methylome",
+        "link": "https://epigenetics.essex.ac.uk/brain/"
+    },
+    "Allelic_skewing": {
+        "title": "Allelic skewing data",
+        "description": "Allelic skewing of DNA methylation is widespread across the genome",
+        "link": "https://epigenetics.essex.ac.uk/ASM/"
+    },
+    "Allelic_expression": {
+        "title": "Allelic Expression data",
+        "description": "Stochastic choice of allelic expression in human neural stem cells",
+        "link": "https://epigenetics.essex.ac.uk/aaron/"
+    },
+    "Methylomic_trajectories": {
+        "title": "Human fetal brain Methylomic trajectories",
+        "description": "Methylomic trajectories across human fetal brain development",
+        "link": "https://epigenetics.essex.ac.uk/fetalbrain/"
+    },
+    "Psychosis": {
+        "title": "Monozygotic twin data",
+        "description": "Disease-associated epigenetic changes in monozygotic twins discordant for schizophrenia and bipolar disorder",
+        "link": "https://epigenetics.essex.ac.uk/psychosis/"
+    },
+    "XXY": {
+        "title": "XXY karyotype data",
+        "description": "Epigenomic and transcriptomic signatures of a 47,XXY karyotype in the brain",
+        "link": "https://epigenetics.essex.ac.uk/XXY/"
+    },
+    "Histone_association": {
+        "title": "Alzheimer's disease H3K27ac data",
+        "description": "A histone acetylome-wide association study of Alzheimer's disease",
+        "link": "https://epigenetics.essex.ac.uk/AD_H3K27ac/"
+    },
+    "Tissue-patterns": {
+        "title": "Tissue-specific patterns of allelically-skewed DNA methylation",
+        "description": "Tissue-specific patterns of allelically-skewed DNA methylation",
+        "link": "https://epigenetics.essex.ac.uk/ASMBrainBlood/"
+    },
+    "DNAm-comparison-tool": {
+        "title": "Blood Brain DNA Methylation Comparison Tool",
+        "description": "Blood Brain DNA Methylation Comparison Tool",
+        "link": "https://epigenetics.essex.ac.uk/bloodbrain/"
+    },
+    "HABIT": {
+        "title": "HABIT",
+        "description": "Hydroxymethylation Annotation in Brain Integrative Tool (HABIT)",
+        "link": "https://epigenetics.essex.ac.uk/HMC/"
+    },
+    "development-mQTL-brain": {
+        "title": "Schizophrenia mQTL data",
+        "description": "Methylation quantitative trait loci (mQTL) in the developing human brain and their enrichment in genomic regions associated with schizophrenia.",
+        "link": "https://epigenetics.essex.ac.uk/mQTL/"
+    }
+}

--- a/assets/data/shiny-apps.json
+++ b/assets/data/shiny-apps.json
@@ -1,0 +1,22 @@
+{
+    "EPICDNAmPowerCalcs": {
+        "title": "EPICDNAmPowerCalcs",
+        "description": "Web app designed to perform power calculations for DNA methylation studies.",
+        "link": "https://epigenetics.essex.ac.uk/shiny/EPICDNAmPowerCalcs/"
+    },
+    "MetaAna": {
+        "title": "MetaAna",
+        "description": "Meta-analysis of epigenome-wide association studies in Alzheimer's disease",
+        "link": "https://epigenetics.essex.ac.uk/shiny/MetaAna/"
+    },
+    "SMR": {
+        "title": "SMR",
+        "description": "Leveraging DNA methylation quantitative trait loci to characterize the relationship between methylomic variation, gene expression and complex traits.",
+        "link": "https://epigenetics.essex.ac.uk/shiny/ShinySMR/"
+    },
+    "LRBrainCoverage": {
+        "title": "LRBrainCoverage",
+        "description": "Summary of isoform expression values in human cortex from long-read transcriptome sequencing",
+        "link": "https://chundruvk.shinyapps.io/LRBrainCoverage/"
+    }
+}

--- a/assets/sass/code.scss
+++ b/assets/sass/code.scss
@@ -28,6 +28,25 @@
     grid-template-columns: 1fr 1fr 1fr;
     row-gap: 5px;
     justify-items: center;
+
+    .shiny-app {
+        border: 1px solid #E4E2E2;
+        border-radius: 2%;
+        padding: 2%;
+        text-decoration: none;
+        width: 90%;
+
+        h3 {
+            @include main-text(1.5rem);
+            color: #198CE7;
+        }
+
+        p {
+            @include main-text(1rem);
+            color: #333;
+        }
+
+    }
 }
 
 @media only screen and (max-width: $smaller_screen_threshold_width) {

--- a/assets/sass/partials/theme.scss
+++ b/assets/sass/partials/theme.scss
@@ -13,11 +13,15 @@ $themes: (
     light: (text: $dark_text_colour,
         bg: white,
         svg: brightness(0) saturate(100%) invert(0%),
+        repobg: white,
+        repoheader: #198CE7,
 
     ),
     dark: (text: white,
         bg: #333333,
         svg: brightness(0) saturate(100%) invert(100%),
+        repobg: #2C2F33,
+        repoheader: #7289DA,
     ),
 );
 

--- a/assets/sass/reproducibility.scss
+++ b/assets/sass/reproducibility.scss
@@ -31,7 +31,7 @@
 }
 
 @include themify($themes) {
-    .shiny-app {
+    .link-container {
         background-color: themed('repobg');
         border: 1px solid #E4E2E2;
         border-radius: 2%;

--- a/assets/sass/reproducibility.scss
+++ b/assets/sass/reproducibility.scss
@@ -28,24 +28,26 @@
     grid-template-columns: 1fr 1fr 1fr;
     row-gap: 5px;
     justify-items: center;
+}
 
+@include themify($themes) {
     .shiny-app {
+        background-color: themed('repobg');
         border: 1px solid #E4E2E2;
         border-radius: 2%;
         padding: 2%;
         text-decoration: none;
         width: 90%;
 
-        h3 {
-            @include main-text(1.5rem);
-            color: #198CE7;
-        }
-
         p {
             @include main-text(1rem);
-            color: #333;
+            color: themed('text');
         }
 
+        h3 {
+            @include main-text(1rem);
+            color: themed('repoheader');
+        }
     }
 }
 

--- a/assets/sass/reproducibility.scss
+++ b/assets/sass/reproducibility.scss
@@ -22,7 +22,7 @@
     }
 }
 
-.repository-grid {
+.link-grid {
     display: grid;
     margin: 0 5%;
     grid-template-columns: 1fr 1fr 1fr;
@@ -50,7 +50,7 @@
 }
 
 @media only screen and (max-width: $smaller_screen_threshold_width) {
-    .repository-grid {
+    .link-grid {
         grid-template-columns: 1fr 1fr;
 
         img {
@@ -60,7 +60,7 @@
 }
 
 @media only screen and (max-width: $large_mobile_threshold_width) {
-    .repository-grid {
+    .link-grid {
         display: flex;
         flex-direction: column;
 

--- a/layouts/section/reproducibility.html
+++ b/layouts/section/reproducibility.html
@@ -13,6 +13,16 @@
   {{ errorf "Unable to get global resource %q" $path }}
 {{ end }}
 
+{{ $shiny_data := dict }}
+{{ $path := "data/shiny-apps.json" }}
+{{ with resources.Get $path }}
+  {{ with . | transform.Unmarshal }}
+    {{ $shiny_data = . }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get global resource %q" $path }}
+{{ end }}
+
 <div class="description-container">
     <h1>Our Code Repositories</h1>
     <p>
@@ -27,6 +37,24 @@
     {{ range $repo_data }}
     <a href="https://github.com/{{ .username }}/{{ .repo }}" target="_blank" >
         <img class="repository" src="https://github-readme-stats.vercel.app/api/pin/?username={{ .username }}&repo={{ .repo }}&theme=default">
+    </a>
+    {{ end }}
+</div>
+<div class="description-container">
+    <h1>Our Shiny Apps</h1>
+    <p>
+        We believe that reproducibility and accessibility are crucial for
+        scientific progress. <br>
+        To that end, we develop and share interactive R
+        Shiny apps to make our analyses and visualizations readily available to
+        the research community.
+    </p>
+</div>
+<div class="repository-grid">
+    {{ range $shiny_data }}
+    <a class="shiny-app" href="{{.link}}">
+            <h3>{{.title}}</h3>
+            <p>{{.description}}</p>
     </a>
     {{ end }}
 </div>

--- a/layouts/section/reproducibility.html
+++ b/layouts/section/reproducibility.html
@@ -23,6 +23,16 @@
   {{ errorf "Unable to get global resource %q" $path }}
 {{ end }}
 
+{{ $publication_data := dict }}
+{{ $path := "data/publication-data.json" }}
+{{ with resources.Get $path }}
+  {{ with . | transform.Unmarshal }}
+    {{ $publication_data = . }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get global resource %q" $path }}
+{{ end }}
+
 <div class="description-container">
     <h1>Our Code Repositories</h1>
     <p>
@@ -45,13 +55,31 @@
     <p>
         We believe that reproducibility and accessibility are crucial for
         scientific progress. <br>
-        To that end, we develop and share interactive R
-        Shiny apps to make our analyses and visualizations readily available to
-        the research community.
+        To that end, we develop and share interactive R Shiny apps to make our
+        analyses and visualizations readily available to the research
+        community.
     </p>
 </div>
 <div class="link-grid">
     {{ range $shiny_data }}
+    <a class="shiny-app" href="{{.link}}">
+            <h3>{{.title}}</h3>
+            <p>{{.description}}</p>
+    </a>
+    {{ end }}
+</div>
+<div class="description-container">
+    <h1>Publication data</h1>
+    <p>
+        We strongly believe in the importance of open and accessible data for
+        scientific reproducibility.<br>
+        To support this, we make the data from our publications readily
+        available for download. This page provides links to our published
+        datasets.
+    </p>
+</div>
+<div class="link-grid">
+    {{ range $publication_data }}
     <a class="shiny-app" href="{{.link}}">
             <h3>{{.title}}</h3>
             <p>{{.description}}</p>

--- a/layouts/section/reproducibility.html
+++ b/layouts/section/reproducibility.html
@@ -62,7 +62,7 @@
 </div>
 <div class="link-grid">
     {{ range $shiny_data }}
-    <a class="shiny-app" href="{{.link}}">
+    <a class="link-container" href="{{.link}}">
             <h3>{{.title}}</h3>
             <p>{{.description}}</p>
     </a>
@@ -80,7 +80,7 @@
 </div>
 <div class="link-grid">
     {{ range $publication_data }}
-    <a class="shiny-app" href="{{.link}}">
+    <a class="link-container" href="{{.link}}">
             <h3>{{.title}}</h3>
             <p>{{.description}}</p>
     </a>

--- a/layouts/section/reproducibility.html
+++ b/layouts/section/reproducibility.html
@@ -1,5 +1,5 @@
 {{ define "extra_head" }}
-{{ partial "partials/addSass.html" (dict "style" "sass/code.scss") }}
+{{ partial "partials/addSass.html" (dict "style" "sass/reproducibility.scss") }}
 {{ end }}
 
 {{ define "main" }}
@@ -33,7 +33,7 @@
         our featured repositories.
     </p>
 </div>
-<div class="repository-grid">
+<div class="link-grid">
     {{ range $repo_data }}
     <a href="https://github.com/{{ .username }}/{{ .repo }}" target="_blank" >
         <img class="repository" src="https://github-readme-stats.vercel.app/api/pin/?username={{ .username }}&repo={{ .repo }}&theme=default">
@@ -50,7 +50,7 @@
         the research community.
     </p>
 </div>
-<div class="repository-grid">
+<div class="link-grid">
     {{ range $shiny_data }}
     <a class="shiny-app" href="{{.link}}">
             <h3>{{.title}}</h3>


### PR DESCRIPTION
## Description
This pull request will add two more sections to the reproducibility page. One for shiny apps and another for data associated with publications.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Page addition
- [ ] Page Redesign
- [ ] Content addition/change
- [ ] Code refactor
- [ ] Documentation

## Checklist:
- [x] I have checked that the site runs with no errors locally
